### PR TITLE
Documentation Fixes for PSC Setup

### DIFF
--- a/CAInstructions.markdown
+++ b/CAInstructions.markdown
@@ -3,8 +3,8 @@
 The CA needs a few files to operate: one to keep track of the last serial number used by the CA (each certificate must have a unique serial number) and another file to record which certificates have been issued:
 
 ```
-    sudo sh -c "echo '01' > PSC/CA/serial"
-    sudo touch PSC/CA/index.txt
+    sh -c "echo '01' > PSC/CA/serial"
+    touch PSC/CA/index.txt
 ```
 
 The third file is a CA configuration file (refer PSC/openssl.cnf). Though not strictly necessary, it is very convenient when issuing multiple certificates. Edit openssl.cnf, and change the following fields: Here, directory usr must be directory TS, CP, or DP depending on the keys you want to generate.
@@ -48,57 +48,57 @@ Also, add default values for country, province, organization, etc.:
 Generate the root CA key: (Use a random passphrase)
 
 ```
-    sudo openssl genrsa -aes256 -out <ca_name>.key 4096
+    openssl genrsa -aes256 -out <ca_name>.key 4096
 ```
 
 Create the insecure key, the one without a passphrase, and shuffle the key names:
 
 ```
     openssl rsa -in <ca_name>.key -out <ca_name>.key.insecure
-    sudo mv <ca_name>.key.insecure <ca_name>.key
+    mv <ca_name>.key.insecure <ca_name>.key
 ```
 
 Next, create the self-signed root certificate:
 
 ```
-    sudo openssl req -new -x509 -days 3650 -key <ca_name>.key -out <ca_name>.cert -config <openssl_configuration_file>
+    openssl req -new -x509 -days 3650 -key <ca_name>.key -out <ca_name>.cert -config <openssl_configuration_file>
 ```
 
 Add the root certificate and key to the destined folders:
 
 ```
-    sudo mv <ca_name>.key PSC/CA/private/
-    sudo mv <ca_name>.cert PSC/CA/certs/
+    mv <ca_name>.key PSC/CA/private/
+    mv <ca_name>.cert PSC/CA/certs/
 ```
 
 Next create a user key and a certificate signing request in one step: (Enter <usr_common_name> when prompted and use a random passphrase)
 
 ```
-    sudo openssl req -newkey rsa:4096 -keyout <usr_common_name>.key -out <usr_common_name>.csr -config openssl.cnf -days 3650
+    openssl req -newkey rsa:4096 -keyout <usr_common_name>.key -out <usr_common_name>.csr -config openssl.cnf -days 3650
 ```
 
 Create the insecure key, the one without a passphrase, and interchange the key names:
 
 ```
     openssl rsa -in <usr_common_name>.key -out <usr_common_name>.key.insecure
-    sudo mv <usr_common_name>.key.insecure <usr_common_name>.key
+    mv <usr_common_name>.key.insecure <usr_common_name>.key
 ```
 
 Using the CSR, generate a certificate signed by the CA:
 
 ```
-    sudo openssl ca -in <usr_common_name>.csr -config openssl.cnf
+    openssl ca -in <usr_common_name>.csr -config openssl.cnf
 ```
  
 Rename certificate file:
 
 ```
-    sudo mv PSC/<usr>/certs/<index>.pem PSC/<usr>/certs/<usr_common_name>.cert
+    mv PSC/<usr>/certs/<index>.pem PSC/<usr>/certs/<usr_common_name>.cert
 ```
 
 Add the user certificate and key in the destined folders:
 
 ```
-    sudo mv <usr_common_name>.csr PSC/<usr>/csr/
-    sudo mv <usr_common_name>.key PSC/<usr>/private/
+    mv <usr_common_name>.csr PSC/<usr>/csr/
+    mv <usr_common_name>.key PSC/<usr>/private/
 ```

--- a/DEPLOY.markdown
+++ b/DEPLOY.markdown
@@ -126,6 +126,10 @@ Set the TS information in PSC/DP/ts.info:
 
 #### Relay Creation
 
+The most up to date instructions are located here:
+
+https://github.com/privcount/privcount/blob/master/DEPLOY.markdown#data-collectors
+
 If you are setting up your relays for the first time, we recommend you use a
 script to create consistent relay configs. Debian and Ubuntu have:
 

--- a/DEPLOY.markdown
+++ b/DEPLOY.markdown
@@ -57,6 +57,7 @@ Set the PSC parameters in PSC/TS/config/Gen_Config.go:
 And generate configuration:
 
 ```
+    nv on goenv
     cd PSC/TS/config/
     go run Gen_Config.go
 ```
@@ -65,18 +66,12 @@ Be careful while collecting and releasing PSC results: the configured epsilon an
 
 PSC is not designed for automated collection and results release: a long enough series of results can identify the activity of a single user.
 
-After configuring parameters, run Gen_Config.go:
-
-```
-    cd PSC/TS/config
-    go run Gen_Config.go
-```
-
 #### PSC      
 
 Then run PSC in Tally Server mode:
 
 ```
+    nv on goenv
     cd PSC/TS/
     go run ts.go -t "<TS_common_name>" -p "<TS_port>"
 ```
@@ -107,6 +102,7 @@ Set the TS information in PSC/CP/ts.info:
 Run PSC in Computation Party mode:
 
 ```
+    nv on goenv
     cd PSC/CP/
     go run cp.go -c "<CP_common_name>" -p "<CP_port>"
 ```
@@ -206,6 +202,7 @@ Start tor relay manually:
 Then run PSC in Data Party mode:
 
 ```
+    nv on goenv
     cd PSC/DP/
     go run ts.go -d "<DP_common_name>" -p "<DP_port>"
 ```

--- a/INSTALL.markdown
+++ b/INSTALL.markdown
@@ -22,11 +22,11 @@ Restart your terminal.
 
 ### Create an environment <goenvironment_name> with go 1.7 or later
 
-    nv mk <goenvironment_name> --go-prebuilt=1.7.5
+    nv mk goenv --go-prebuilt=1.7.5
 
 ### Activate environment
 
-    nv on <goenvironment_name>
+    nv on goenv
 
 ### Install PSC dependancies
 

--- a/INSTALL.markdown
+++ b/INSTALL.markdown
@@ -42,7 +42,7 @@ Restart your terminal.
 
 ### Upgrade PSC
 
-    cd $GOPATH/src
+    cd $GOPATH/src/PSC
     git pull
 
 ### Deactivate environment

--- a/INSTALL.markdown
+++ b/INSTALL.markdown
@@ -53,6 +53,10 @@ Restart your terminal.
 
 A custom compiled PrivCount-patched Tor can be used to run a Data Party.
 
+The most up to date instructions are located here:
+
+https://github.com/privcount/privcount/blob/master/INSTALL.markdown#installing-a-privcount-patched-tor-data-collectors
+
 ### Tor Dependencies
 
     Debian/Ubuntu:  libssl-dev libevent-dev

--- a/INSTALL.markdown
+++ b/INSTALL.markdown
@@ -58,8 +58,6 @@ A custom compiled PrivCount-patched Tor can be used to run a Data Party.
     Debian/Ubuntu:  libssl-dev libevent-dev
     Other Linux:    libssl libssl-dev libevent libevent-devel
 
-### Tor Dependencies
-
 #### Linux Sandbox (Optional)
 
     Debian/Ubuntu:  libseccomp-dev

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See INSTALL.markdown for details.
 To run PSC, simply activate the virtual environment that you created earlier and then run PSC. For example:
 
 ```
-  nv on <goenvironment_name>
+  nv on goenv
   ...
   nv off
 ```


### PR DESCRIPTION
This branch fixes some typos and mistakes in the PSC documentation.
It also points to the PrivCount documentation where appropriate.