### PR TITLE
Don't use sudo in keypair.sh

### DIFF
--- a/keypair.sh
+++ b/keypair.sh
@@ -1,7 +1,7 @@
-sudo openssl req -newkey rsa:4096 -keyout $2.key -out $2.csr -config openssl.cnf -days 3650
+openssl req -newkey rsa:4096 -keyout $2.key -out $2.csr -config openssl.cnf -days 3650
 openssl rsa -in $2.key -out $2.key.insecure
-sudo mv $2.key.insecure $2.key
-sudo openssl ca -in $2.csr -config openssl.cnf
-sudo mv $1/certs/*.pem $1/certs/$2.cert
-sudo mv $2.csr $1/csr/
-sudo mv $2.key $1/private/
+mv $2.key.insecure $2.key
+openssl ca -in $2.csr -config openssl.cnf
+mv $1/certs/*.pem $1/certs/$2.cert
+mv $2.csr $1/csr/
+mv $2.key $1/private/

--- a/keypair.sh
+++ b/keypair.sh
@@ -2,6 +2,6 @@ openssl req -newkey rsa:4096 -keyout $2.key -out $2.csr -config openssl.cnf -day
 openssl rsa -in $2.key -out $2.key.insecure
 mv $2.key.insecure $2.key
 openssl ca -in $2.csr -config openssl.cnf
-mv $1/certs/*.pem $1/certs/$2.cert
+mv CA/certs/*.pem $1/certs/$2.cert
 mv $2.csr $1/csr/
 mv $2.key $1/private/


### PR DESCRIPTION
Running commands as root is insecure. And it doesn't work on all distributions.